### PR TITLE
Added BKL to Coastviewer

### DIFF
--- a/src/components/LayerControl.vue
+++ b/src/components/LayerControl.vue
@@ -12,7 +12,7 @@
   <div class="layer-div">
     <draggable class="draggable" v-model="menulayers" @start="drag=true" @end="drag=false; sortLayers()">
       <v-list three-line dense pt-0 v-for="layer in layers" :key="layer.id">
-        <v-list-group v-if="layer.name === 'kustindicatoren'">
+        <v-list-group v-if="layer.name === 'kustindicatoren' || layer.name === 'BKL lijn'">
           <template v-slot:activator>
             <v-list-tile>
               <v-list-tile-action>
@@ -172,7 +172,7 @@ export default {
               bus.$emit('set-active')
               this.map.setLayoutProperty(sublayer.id, 'visibility', vis[1])
             } else {
-              if (layer.name==="kustindicatoren") {
+              if (layer.name==="kustindicatoren" || layer.name==="BKL lijn") {
                 bus.$emit('set-inactive')
               }
               this.map.setLayoutProperty(sublayer.id, 'visibility', vis[0])

--- a/static/data/datalayers.json
+++ b/static/data/datalayers.json
@@ -571,6 +571,85 @@
     ]
   },
   {
+    "name": "BKL lijn",
+    "layertype": "mapbox-layer-group",
+    "active": false,
+    "legendlabels": [
+      "BKL 1992",
+      "BKL 2001",
+      "BKL 2012",
+      "BKL 2017"
+    ],
+    "legendcolors": [
+      "#000099",
+      "#33ccff",
+      "#ffcc00",
+      "#996600"
+    ],
+    "data": [
+      {
+        "id": "bkl1992",
+        "type": "line",
+        "source": {
+          "url": "mapbox://coastviewer.9og64q6u",
+          "type": "vector"
+        },
+	    "source-layer": "BKL_1992-0jgsf1",
+      "paint": {
+        "line-color": "#8f6558",
+        "line-width": 2
+        },
+      "label": "BKL Lijn 1992",
+      "active": false
+      },
+      {
+        "id": "bkl2001",
+        "type": "line",
+        "source": {
+          "url": "mapbox://coastviewer.6av9w8o0",
+          "type": "vector"
+        },
+	    "source-layer": "BKL_2001-3w3cds",
+      "paint": {
+        "line-color": "#F23C15",
+        "line-width": 2
+        },
+      "label": "BKL Lijn 2001",
+      "active": false
+      },
+      {
+        "id": "bkl2012",
+        "type": "line",
+        "source": {
+          "url": "mapbox://coastviewer.chbcj7p5",
+          "type": "vector"
+        },
+	    "source-layer": "BKL_2012-8gkbbm",
+      "paint": {
+        "line-color": "#EF15F2",
+        "line-width": 2
+        },
+      "label": "BKL Lijn 2012",
+      "active": false
+      },
+      {
+        "id": "bkl2017",
+        "type": "line",
+        "source": {
+          "url": "mapbox://coastviewer.1di0yqoa",
+          "type": "vector"
+        },
+	    "source-layer": "BKL_2017-1bsoxk",
+      "paint": {
+        "line-color": "#1DF215",
+        "line-width": 2
+        },
+      "label": "BKL Lijn 2017",
+      "active": false
+      }
+    ]
+  },
+  {
     "name": "Kustlijnkaartenboek",
     "layertype": "mapbox-layer-group",
     "active": false,


### PR DESCRIPTION
The BKLs were uploaded to the Deltares MapBox studio account, and the code was modified to  display the following BKLs: 1992, 2001, 2012, 2017.
The data was received from RWS